### PR TITLE
Missing charset

### DIFF
--- a/oauth/authorize.php
+++ b/oauth/authorize.php
@@ -36,6 +36,7 @@ if (empty($_POST)) {
 <!DOCTYPE html>
 <html>
   <head>
+    <meta charset="UTF-8" />
       <link rel="stylesheet" type="text/css" href="./style.css">
     <title>Authorisation Mattermost</title>
   </head>


### PR DESCRIPTION
`authorize.php` does not declare a charset, which causes this kind of issues in non-ASCII languages:
![image](https://user-images.githubusercontent.com/840125/32790633-439f2702-c95f-11e7-9d78-5311e3d5534b.png)
