### PR TITLE
fix for issue #24

### DIFF
--- a/oauth/resource.php
+++ b/oauth/resource.php
@@ -24,7 +24,7 @@ $resp = array("error" => "Unknown error", "message" => "An unknown error has occ
 // get information on user associated to the token
 $info_oauth = $server->getAccessTokenData(OAuth2\Request::createFromGlobals());
 $user = $info_oauth["user_id"];
-$assoc_id = $info_oauth["assoc_id"];
+$assoc_id = intval($info_oauth["assoc_id"]);
 
 // Open a LDAP connection
 $ldap = new LDAP($hostname,$port,$ldap_version);


### PR DESCRIPTION
Golang GitLab module awaits an integer and crashes if a string is provided in the json response, this is a dirty fix.