### PR TITLE
Fixed failing oauth if username case changed

### DIFF
--- a/oauth/authorize.php
+++ b/oauth/authorize.php
@@ -111,7 +111,7 @@ if (empty($_POST)) {
 
 // print the authorization code if the user has authorized your client
 $is_authorized = ($_POST['authorized'] === 'Authorize');
-$server->handleAuthorizeRequest($request, $response, $is_authorized,$_SESSION['uid']);
+$server->handleAuthorizeRequest($request, $response, $is_authorized,strtolower($_SESSION['uid']));
 
 if ($is_authorized) 
 {

--- a/oauth/connexion.php
+++ b/oauth/connexion.php
@@ -33,7 +33,7 @@ else
    		// Remove every html tag and useless space on username (to prevent XSS)
    	   	$user=strip_tags(trim($_POST['user']));
 
-    	$user=$_POST['user'];
+    	$user=strtolower($_POST['user']);
     	$password=$_POST['password'];
 
     	// Open a LDAP connection


### PR DESCRIPTION
If the user had previously logged into mattermost as "user" and then tried to connect another device as "User", a new set of entries would be created in the database which caused user IDs to not match up which caused Mattermost to throw an error about the account already being registered under a different service. This change ensures usernames are always processed in lowercase so that this can't happen.

Note that manual fixups of any existing entries in the mattermost-ldap database may need to be performed to fully fix everything. This just prevents the issue from occurring again in a very simple way. A more thorough fix would be to make the db queries check in a case-insensitive matter, though multiple entries in the users database would still exist.

This could be made into a config setting if desired, though for our use case (Microsoft AD server) the usernames themselves are always case-insensitive.