### PR TITLE
Pin to centos7

### DIFF
--- a/Docker/oauth/Dockerfile
+++ b/Docker/oauth/Dockerfile
@@ -4,10 +4,10 @@
 # > https://github.com/crivaledaz/Mattermost-LDAP
 
 # Start from a CentOS 7 image
-FROM centos:latest
+FROM centos:centos7
 
 # Update packages and install dependencies
-RUN yum update -y && yum -y install httpd php postgresql php-ldap php-pdo php-pgsql git
+RUN yum update -y && yum -y install httpd php postgresql php-ldap php-pdo php-pgsql php-xml git
 
 # Retrieve Mattermost-LDAP from git repository
 RUN git clone https://github.com/crivaledaz/Mattermost-LDAP.git Mattermost-LDAP/


### PR DESCRIPTION
I was trying to get this image stood up and :latest was pulling 8, which apparently had problems with the unforked httpd and php-fpm. Pinning to centos7 (and also adding the php-xml package) seemed to fix the problem for me.