### PR TITLE
Return the displayName from LDAP so users have proper names

### DIFF
--- a/oauth/LDAP/LDAP.php
+++ b/oauth/LDAP/LDAP.php
@@ -154,7 +154,7 @@ class LDAP implements LDAPInterface
     */
     public function getDataForMattermost($ldap_base_dn, $ldap_filter, $ldap_bind_dn, $ldap_bind_pass, $ldap_search_attribute, $user)
     {
-        $attribute=array("cn","mail");
+        $attribute=array("cn","mail","displayName");
 
         if (!is_string($ldap_base_dn)) {
             throw new InvalidArgumentException('First argument to LDAP/getData must be the ldap base directory name (string). Ex: o=Company');
@@ -212,7 +212,13 @@ class LDAP implements LDAPInterface
             throw new Exception('An error has occured during ldap_get_values execution (complete name). Please check parameter of LDAP/getData.');
         }
 
-        return array("mail" => $mail[0], "cn" => $cn[0]);
+        $displayName = ldap_get_values($this->ldap_server, $data, "displayName");
+        if (!$cn) {
+            throw new Exception('An error has occured during ldap_get_values execution (displayName). Please check parameter of LDAP/getData.');
+        }
+
+
+        return array("mail" => $mail[0], "cn" => $cn[0], "displayName" => $displayName[0]);
     }
 
     /*

--- a/oauth/resource.php
+++ b/oauth/resource.php
@@ -36,7 +36,7 @@ try {
     // Here is the patch for Mattermost 4.4 and newer. Gitlab has changed the JSON output of oauth service. Many data are not used by Mattermost, but there is a stack error if we delete them. That's the reason why date and many parameters are null or empty.
     $resp = array(
 	"id" => $assoc_id,
-	"name" => $data['cn'],
+	"name" => $data['displayName'],
 	"username" => $user,
 	"state" => "active",
 	"avatar_url" => "",


### PR DESCRIPTION
Currently the oauth is returning "cn" for the name to Mattermost, which is not generally an attribute intended for display.

Active Directory and the RFC openldap schemas have displayName for this.
