### PR TITLE
Change parameter order to prevent PHP 8.1 deprecation warning

### DIFF
--- a/oauth/LDAP/LDAP.php
+++ b/oauth/LDAP/LDAP.php
@@ -75,7 +75,7 @@ class LDAP implements LDAPInterface
     * TRUE if the user is identified and can access to the LDAP server
     * and FALSE if it isn't
     */
-    public function checkLogin($user, $password = null, $ldap_search_attribute, $ldap_filter = null, $ldap_base_dn, $ldap_bind_dn, $ldap_bind_pass)
+    public function checkLogin($user, $ldap_search_attribute, $ldap_base_dn, $ldap_bind_dn, $ldap_bind_pass, $password = null, $ldap_filter = null)
     {
         if (!is_string($user)) {
             throw new InvalidArgumentException('First argument to LDAP/checkLogin must be the username or email of a ldap user (string). Ex: jdupont or jdupont@company.com');

--- a/oauth/LDAP/LDAPInterface.php
+++ b/oauth/LDAP/LDAPInterface.php
@@ -27,7 +27,7 @@ interface LDAPInterface
     * TRUE if the user is identified and can access to the LDAP server
     * and FALSE if it isn't
     */
-    public function checkLogin($user, $password = null, $ldap_search_attribute, $ldap_filter = null, $ldap_base_dn, $ldap_bind_dn, $ldap_bind_pass);
+    public function checkLogin($user, $ldap_search_attribute, $ldap_base_dn, $ldap_bind_dn, $ldap_bind_pass, $password = null, $ldap_filter = null);
 
     /**
      * @param string @ldap_base_dn

--- a/oauth/index.php
+++ b/oauth/index.php
@@ -56,7 +56,7 @@ else
 
         // Check user credential on LDAP
         try{
-            $authenticated = $ldap->checkLogin($user,$password,$ldap_search_attribute,$ldap_filter,$ldap_base_dn,$ldap_bind_dn,$ldap_bind_pass);
+            $authenticated = $ldap->checkLogin($user,$ldap_search_attribute,$ldap_base_dn,$ldap_bind_dn,$ldap_bind_pass,$password,$ldap_filter);
         }
         catch (Exception $e)
         {


### PR DESCRIPTION
I have made some changes to not get this warning:

> Deprecated: Optional parameter $ldap_filter declared before required parameter $ldap_bind_pass is implicitly treated as a required parameter in /var/www/html/auth/LDAP/LDAPInterface.php on line 30

Maybe it would help others to include this in your codebase.