### PR TITLE
Fix for the init script for Postgres 15

### DIFF
--- a/db_init/init_postgres.sh
+++ b/db_init/init_postgres.sh
@@ -36,7 +36,7 @@ sleep 5
 info "Creation of role $db_user and database $db_name ..."
 psql -U postgres -c "CREATE DATABASE $db_name;"
 psql -U postgres -c "CREATE USER $db_user WITH ENCRYPTED PASSWORD '$db_pass';"
-psql -U postgres -c "GRANT ALL PRIVILEGES ON DATABASE $db_name TO $db_user;"
+psql -U postgres -c "ALTER DATABASE  $db_name OWNER TO $db_user;"
 
 #Creating tables for ouath database (use oauth role)
 info "Creation of tables for database $db_name (using $db_user)"


### PR DESCRIPTION
The Demo docker-compose file has no major version set for Postgres and the DB init-script fails for Postgres 15.

A possible fix is to make the database user the owner of the created database within the init script.

Background informations:

- https://stackoverflow.com/questions/74110708/postgres-15-permission-denied-for-schema-public
- https://www.postgresql.org/about/news/postgresql-15-released-2526/
  Other Notable Changes: "PostgreSQL 15 also revokes the CREATE permission from all users except a database owner from the public (or default) schema."