### PR TITLE
fix: prevent LDAP injection by validating and escaping username input

### DIFF
--- a/oauth/index.php
+++ b/oauth/index.php
@@ -51,6 +51,22 @@ else
         $user=strtolower(strip_tags(htmlspecialchars(trim($_POST['user']))));
         $password=$_POST['password'];
 
+        // Validate username against a safe pattern (alphanumeric, dot, underscore, dash)
+        if (!preg_match('/^[a-zA-Z0-9._-]{1,64}$/', $user)) {
+            messageShow($prompt_template, 'Username contains invalid characters. Please try again.');
+            exit();
+        }
+
+        // Escape LDAP special characters in username
+        if (!function_exists('ldap_escape')) {
+            function ldap_escape($value) {
+                return preg_replace_callback('/[\\x00-\\x1F\\x7F\\(\\)\\\\\\*\\0]/', function ($matches) {
+                    return '\\' . str_pad(dechex(ord($matches[0])), 2, '0', STR_PAD_LEFT);
+                }, $value);
+            }
+        }
+        $user = ldap_escape($user);
+
         // Open a LDAP connection
         $ldap = new LDAP($ldap_host,$ldap_port,$ldap_version,$ldap_start_tls);
 


### PR DESCRIPTION
fix for [ldap-injection-issue](https://github.com/Crivaledaz/Mattermost-LDAP/issues/118#issue-3245018927)